### PR TITLE
Add operation to create a grid

### DIFF
--- a/lib/identicon.ex
+++ b/lib/identicon.ex
@@ -3,10 +3,7 @@ defmodule Identicon do
     input
     |> hash_input
     |> pick_color
-  end
-
-  def pick_color(%Identicon.Image{hex: [r, g, b | _tail]} = image) do
-    %Identicon.Image{image | color: {r, g, b}}
+    |> build_grid
   end
 
   def hash_input(input) do
@@ -15,5 +12,14 @@ defmodule Identicon do
       |> :binary.bin_to_list()
 
     %Identicon.Image{hex: hex}
+  end
+
+  def pick_color(%Identicon.Image{hex: [r, g, b | _tail]} = image) do
+    %Identicon.Image{image | color: {r, g, b}}
+  end
+
+  def build_grid(%Identicon.Image{hex: hex}) do
+    hex
+    |> Enum.chunk_every(3)
   end
 end

--- a/lib/identicon.ex
+++ b/lib/identicon.ex
@@ -21,6 +21,7 @@ defmodule Identicon do
   def build_grid(%Identicon.Image{hex: hex}) do
     hex
     |> Enum.chunk_every(3, 3, :discard)
+    |> Enum.map(&mirrow_row/1)
   end
 
   def mirrow_row([first, second | _tail] = row) do

--- a/lib/identicon.ex
+++ b/lib/identicon.ex
@@ -18,12 +18,15 @@ defmodule Identicon do
     %Identicon.Image{image | color: {r, g, b}}
   end
 
-  def build_grid(%Identicon.Image{hex: hex}) do
-    hex
-    |> Enum.chunk_every(3, 3, :discard)
-    |> Enum.map(&mirrow_row/1)
-    |> List.flatten()
-    |> Enum.with_index()
+  def build_grid(%Identicon.Image{hex: hex} = image) do
+    grid =
+      hex
+      |> Enum.chunk_every(3, 3, :discard)
+      |> Enum.map(&mirrow_row/1)
+      |> List.flatten()
+      |> Enum.with_index()
+
+    %Identicon.Image{image | grid: grid}
   end
 
   def mirrow_row([first, second | _tail] = row) do

--- a/lib/identicon.ex
+++ b/lib/identicon.ex
@@ -22,6 +22,8 @@ defmodule Identicon do
     hex
     |> Enum.chunk_every(3, 3, :discard)
     |> Enum.map(&mirrow_row/1)
+    |> List.flatten()
+    |> Enum.with_index()
   end
 
   def mirrow_row([first, second | _tail] = row) do

--- a/lib/identicon.ex
+++ b/lib/identicon.ex
@@ -20,6 +20,6 @@ defmodule Identicon do
 
   def build_grid(%Identicon.Image{hex: hex}) do
     hex
-    |> Enum.chunk_every(3)
+    |> Enum.chunk_every(3, 3, :discard)
   end
 end

--- a/lib/identicon.ex
+++ b/lib/identicon.ex
@@ -22,4 +22,8 @@ defmodule Identicon do
     hex
     |> Enum.chunk_every(3, 3, :discard)
   end
+
+  def mirrow_row([first, second | _tail] = row) do
+    row ++ [second, first]
+  end
 end

--- a/lib/image.ex
+++ b/lib/image.ex
@@ -1,3 +1,3 @@
 defmodule Identicon.Image do
-  defstruct hex: nil, color: nil
+  defstruct hex: nil, color: nil, grid: nil
 end


### PR DESCRIPTION
## Why?

In order to start mapping the structure of the grid itself, the stream of data, formed a list in the form of `hex`, which could be converted to list of tuples, containing specific index for each value