### PR TITLE
Add processing to generate coordinates for filled rectangules

### DIFF
--- a/lib/identicon.ex
+++ b/lib/identicon.ex
@@ -5,6 +5,7 @@ defmodule Identicon do
     |> pick_color
     |> build_grid
     |> filter_tofill_squares
+    |> build_pixel_map
   end
 
   def hash_input(input) do
@@ -38,5 +39,20 @@ defmodule Identicon do
     filtered = Enum.filter(grid, fn {code, _index} -> rem(code, 2) == 0 end)
 
     %Identicon.Image{image | grid: filtered}
+  end
+
+  def build_pixel_map(%Identicon.Image{grid: grid} = image) do
+    pixel_map =
+      Enum.map(grid, fn {_code, index} ->
+        x_axys = rem(index, 5) * 50
+        y_axys = div(index, 5) * 50
+
+        top_left = {x_axys, y_axys}
+        bottom_right = {x_axys + 50, y_axys + 50}
+
+        {top_left, bottom_right}
+      end)
+
+    %Identicon.Image{image | pixel_map: pixel_map}
   end
 end

--- a/lib/identicon.ex
+++ b/lib/identicon.ex
@@ -4,6 +4,7 @@ defmodule Identicon do
     |> hash_input
     |> pick_color
     |> build_grid
+    |> filter_tofill_squares
   end
 
   def hash_input(input) do
@@ -31,5 +32,11 @@ defmodule Identicon do
 
   def mirrow_row([first, second | _tail] = row) do
     row ++ [second, first]
+  end
+
+  def filter_tofill_squares(%Identicon.Image{grid: grid} = image) do
+    filtered = Enum.filter(grid, fn {code, _index} -> rem(code, 2) == 0 end)
+
+    %Identicon.Image{image | grid: filtered}
   end
 end

--- a/lib/image.ex
+++ b/lib/image.ex
@@ -1,3 +1,3 @@
 defmodule Identicon.Image do
-  defstruct hex: nil, color: nil, grid: nil
+  defstruct hex: nil, color: nil, grid: nil, pixel_map: nil
 end


### PR DESCRIPTION
## Why?

In order to find the exact and unique coordinates inside the `250pxX250px` grid, it is necessary to map each point of the top left and right bottom of the rectangles